### PR TITLE
Fix - HintTooltip Indentation

### DIFF
--- a/src/FSharpVSPowerTools.Logic/Outlining/OutliningTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/Outlining/OutliningTagger.fs
@@ -28,7 +28,7 @@ type OutliningTagger
     (textDocument: ITextDocument,
      serviceProvider : IServiceProvider,
      projectFactory: ProjectFactory,
-     languageService: VSLanguageService) as self = 
+     languageService: VSLanguageService) as self =
 
     let buffer = textDocument.TextBuffer
     let tagsChanged = Event<_,_> ()
@@ -93,7 +93,7 @@ type OutliningTagger
             let rec loop acc  =
                 if acc >= charr.Length then acc 
                 elif not (Char.IsWhiteSpace charr.[acc]) then acc else loop (acc+1) in loop 0
-        let lines = text.Split [|'\n'|]
+        let lines = lineSplit text
         let minlead = 
             let seed = if lines = [||] then 0 else lines.[0] |> leadingWhitespace
             (seed, lines) ||> Array.fold (fun acc elm -> leadingWhitespace elm |> min acc)

--- a/src/FSharpVSPowerTools.Logic/VSUtils.fs
+++ b/src/FSharpVSPowerTools.Logic/VSUtils.fs
@@ -437,3 +437,37 @@ let listFSharpProjectsInSolution (dte: DTE) =
 
     [ for p in dte.Solution.Projects do
         yield! handleProject p ]
+
+
+
+/// Linux linebreak `\n`
+let [<Literal>] linuxLineBreak = "\n"
+
+/// Windows linebreak `\r\n`
+let [<Literal>] windowsLineBreak = "\r\n"
+
+/// Mac linebreak `\r`
+let [<Literal>] macLineBreak = "\r"
+
+/// Replaces pattern in the string with the replacement
+let inline replace (pattern:string) replacement (text:string) = text.Replace(pattern, replacement)
+
+/// Converts all linebreaks in a string to windows linebreaks
+let convertToWindowsLineBreaks text = 
+    replace windowsLineBreak linuxLineBreak 
+        >> replace macLineBreak linuxLineBreak 
+            >> replace linuxLineBreak windowsLineBreak <| text
+
+/// Splits a string into lines for all platform's linebreaks.
+/// If the string mixes windows, mac, and linux linebreaks, all will be respected
+let lineSplit str = (convertToWindowsLineBreaks str).Split([|windowsLineBreak|],StringSplitOptions.None)
+
+type String with
+    /// Replaces pattern in the string with the replacement
+    static member inline replace pattern replacement text = replace pattern replacement text
+    /// Splits a string into lines for all platform's linebreaks.
+    /// If the string mixes windows, mac, and linux linebreaks, all will be respected
+    static member toLineArray str = lineSplit str
+    /// Splits a string into lines for all platform's linebreaks.
+    /// If the string mixes windows, mac, and linux linebreaks, all will be respected
+    member self.ToLineArray () = lineSplit self

--- a/src/FSharpVSPowerTools.Logic/VSUtils.fs
+++ b/src/FSharpVSPowerTools.Logic/VSUtils.fs
@@ -439,7 +439,6 @@ let listFSharpProjectsInSolution (dte: DTE) =
         yield! handleProject p ]
 
 
-
 /// Linux linebreak `\n`
 let [<Literal>] linuxLineBreak = "\n"
 
@@ -449,25 +448,23 @@ let [<Literal>] windowsLineBreak = "\r\n"
 /// Mac linebreak `\r`
 let [<Literal>] macLineBreak = "\r"
 
-/// Replaces pattern in the string with the replacement
-let inline replace (pattern:string) replacement (text:string) = text.Replace(pattern, replacement)
-
-/// Converts all linebreaks in a string to windows linebreaks
-let convertToWindowsLineBreaks text = 
-    replace windowsLineBreak linuxLineBreak 
-        >> replace macLineBreak linuxLineBreak 
-            >> replace linuxLineBreak windowsLineBreak <| text
 
 /// Splits a string into lines for all platform's linebreaks.
 /// If the string mixes windows, mac, and linux linebreaks, all will be respected
-let lineSplit str = (convertToWindowsLineBreaks str).Split([|windowsLineBreak|],StringSplitOptions.None)
+let inline lineSplit (str:string) = str.Split([|windowsLineBreak;linuxLineBreak;macLineBreak|],StringSplitOptions.None)
 
 type String with
-    /// Replaces pattern in the string with the replacement
-    static member inline replace pattern replacement text = replace pattern replacement text
+
     /// Splits a string into lines for all platform's linebreaks.
     /// If the string mixes windows, mac, and linux linebreaks, all will be respected
     static member toLineArray str = lineSplit str
+
     /// Splits a string into lines for all platform's linebreaks.
     /// If the string mixes windows, mac, and linux linebreaks, all will be respected
     member self.ToLineArray () = lineSplit self
+
+    /// Return substring starting at index, returns the same string if given a negative index
+    /// if given an index > string.Length returns empty string
+    member self.SubstringSafe index =
+        if   index < 0 then self elif index > self.Length then "" else self.Substring index
+


### PR DESCRIPTION
Converting all the linebreaks to one form before splitting was unnecessary 

There was a slight issue with the hint tooltips where if a span being outlined contained an empty line or a whitespace line it would skew the min indent calculation and create a gutter.

![](http://i.imgur.com/nQhbPMm.png)

`tidyHintTooltip` now accounts for these cases properly and ignores them when calculating the minimum indentation  and creates the desired hintTooltip

![](http://i.imgur.com/H1yb9JS.png)
